### PR TITLE
Fix whitespace before punctuation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,14 +63,9 @@ Locations:
     <h1>
 <a id="when-and-where" class="anchor" href="#license" aria-hidden="true"><span class="octicon octicon-link"></span></a>License</h1>
     <p>
-The content of this website is available under
-<a href="LICENSE">CC0</a>
-. This website uses the
-<a href="https://github.com/pages-themes/hacker/">hacker template</a>
-which is also available under
-<a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode">CC0</a>
-.
-</p>
+      The content of this website is available under <a href="LICENSE">CC0</a>.
+      This website uses the <a href="https://github.com/pages-themes/hacker/">hacker template</a> which is also available under <a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode">CC0</a>.
+    </p>
       </section>
     </div>
 


### PR DESCRIPTION
Hi, this PR fixes spaces before the punctuation mark in the licensing section.
I also tried to fix the indentations in the surrounding HTML, that's why more than 2 lines are changed.